### PR TITLE
Allow for dynamic number of columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-chrome-bootstrap
+chrome-bootstrap-dynamic
 ================
 
 A Chrome extension to overlay your Bootstrap grid
+
+Forked version of https://github.com/chuckhendo/chrome-bootstrap
+
+Added option for adding an attribute to the body tag for customizing
+number of columns that are overlayed.
+Attribute is optional, fallback to 12 columns.
+
+<body data-bootstrap-num-cols="15">

--- a/grid.js
+++ b/grid.js
@@ -1,26 +1,30 @@
 if (document.getElementsByClassName('cb-grid-lines').length){
-    
+
     document.body.removeChild(document.getElementsByClassName('cb-grid-lines')[0]);
 }
 
 else {
-    document.body.innerHTML += '<div class="cb-grid-lines"> \
+
+    var html = "",
+        numCols = 12,
+        dataNumCols = document.getElementsByTagName("body")[0].getAttribute("data-bootstrap-num-cols");
+
+    if(typeof dataNumCols === "string" && dataNumCols.length){
+        numCols = parseInt(dataNumCols, 10);
+    }
+
+    html += '<div class="cb-grid-lines"> \
       <div class="container"> \
-        <div class="row"> \
-            <div class="span1 col-xs-1"></div> \
-            <div class="span1 col-xs-1"></div> \
-            <div class="span1 col-xs-1"></div> \
-            <div class="span1 col-xs-1"></div> \
-            <div class="span1 col-xs-1"></div> \
-            <div class="span1 col-xs-1"></div> \
-            <div class="span1 col-xs-1"></div> \
-            <div class="span1 col-xs-1"></div> \
-            <div class="span1 col-xs-1"></div> \
-            <div class="span1 col-xs-1"></div> \
-            <div class="span1 col-xs-1"></div> \
-            <div class="span1 col-xs-1"></div> \
-        </div> \
+        <div class="row">';
+
+    for (var i = 0; i < numCols; i += 1) {
+        html += '<div class="span1 col-xs-1"></div>';
+    }
+
+    html += '</div> \
       </div> \
     </div>';
-    
+
+    document.body.innerHTML += html;
+
 }


### PR DESCRIPTION
Added option for adding an attribute to the body tag for customizing
number of columns that are overlayed.
Attribute is optional, fallback to 12 columns.

<body data-bootstrap-num-cols="15">
